### PR TITLE
golang/transport: initial implementation

### DIFF
--- a/golang/api.go
+++ b/golang/api.go
@@ -6,11 +6,10 @@ type Session interface {
 	Close() error
 	Open(ctx context.Context) (Channel, error)
 	Accept() (Channel, error)
-	Wait() error
 }
 
 // A Channel is an ordered, reliable, flow-controlled, duplex stream
-// that is multiplexed over a qmux connection.
+// that is multiplexed over a qmux session.
 type Channel interface {
 	// Read reads up to len(data) bytes from the channel.
 	Read(data []byte) (int, error)
@@ -26,5 +25,7 @@ type Channel interface {
 	// The other side may still send data
 	CloseWrite() error
 
+	// ID returns the unique identifier of this channel
+	// within the session
 	ID() uint32
 }

--- a/golang/go.mod
+++ b/golang/go.mod
@@ -1,3 +1,5 @@
 module github.com/progrium/qmux/golang
 
 go 1.16
+
+require golang.org/x/net v0.0.0-20210420210106-798c2154c571 // indirect

--- a/golang/go.sum
+++ b/golang/go.sum
@@ -1,0 +1,7 @@
+golang.org/x/net v0.0.0-20210420210106-798c2154c571 h1:Q6Bg8xzKzpFPU4Oi1sBnBTHBwlMsLeEXpu4hYBY8rAg=
+golang.org/x/net v0.0.0-20210420210106-798c2154c571/go.mod h1:72T/g9IO56b78aLF+1Kcs5dz7/ng1VjMUvfKvpfy+jM=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210420072515-93ed5bcd2bfe/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/golang/misc.go
+++ b/golang/misc.go
@@ -1,0 +1,15 @@
+package mux
+
+import "fmt"
+
+type waiter interface {
+	Wait() error
+}
+
+func Wait(sess Session) error {
+	w, ok := sess.(waiter)
+	if !ok {
+		return fmt.Errorf("Session does not support waiting")
+	}
+	return w.Wait()
+}

--- a/golang/transport/dial_io.go
+++ b/golang/transport/dial_io.go
@@ -1,0 +1,17 @@
+package transport
+
+import (
+	"io"
+	"os"
+
+	mux "github.com/progrium/qmux/golang"
+	"github.com/progrium/qmux/golang/session"
+)
+
+func DialIO(out io.WriteCloser, in io.ReadCloser) (mux.Session, error) {
+	return session.New(&ioduplex{out, in}), nil
+}
+
+func DialStdio() (mux.Session, error) {
+	return DialIO(os.Stdout, os.Stdin)
+}

--- a/golang/transport/dial_net.go
+++ b/golang/transport/dial_net.go
@@ -1,0 +1,24 @@
+package transport
+
+import (
+	"net"
+
+	mux "github.com/progrium/qmux/golang"
+	"github.com/progrium/qmux/golang/session"
+)
+
+func dialNet(proto, addr string) (mux.Session, error) {
+	conn, err := net.Dial(proto, addr)
+	if err != nil {
+		return nil, err
+	}
+	return session.New(conn), nil
+}
+
+func DialTCP(addr string) (mux.Session, error) {
+	return dialNet("tcp", addr)
+}
+
+func DialUnix(addr string) (mux.Session, error) {
+	return dialNet("unix", addr)
+}

--- a/golang/transport/dial_ws.go
+++ b/golang/transport/dial_ws.go
@@ -1,0 +1,18 @@
+package transport
+
+import (
+	"fmt"
+
+	mux "github.com/progrium/qmux/golang"
+	"github.com/progrium/qmux/golang/session"
+	"golang.org/x/net/websocket"
+)
+
+func DialWS(addr string) (mux.Session, error) {
+	ws, err := websocket.Dial(fmt.Sprintf("ws://%s/", addr), "", fmt.Sprintf("http://%s/", addr))
+	if err != nil {
+		return nil, err
+	}
+	ws.PayloadType = websocket.BinaryFrame
+	return session.New(ws), nil
+}

--- a/golang/transport/listen.go
+++ b/golang/transport/listen.go
@@ -1,0 +1,8 @@
+package transport
+
+import mux "github.com/progrium/qmux/golang"
+
+type Listener interface {
+	Close() error
+	Accept() (mux.Session, error)
+}

--- a/golang/transport/listen_io.go
+++ b/golang/transport/listen_io.go
@@ -1,0 +1,42 @@
+package transport
+
+import (
+	"io"
+	"os"
+
+	mux "github.com/progrium/qmux/golang"
+	"github.com/progrium/qmux/golang/session"
+)
+
+type IOListener struct {
+	io.ReadWriteCloser
+}
+
+func (l *IOListener) Accept() (mux.Session, error) {
+	return session.New(l.ReadWriteCloser), nil
+}
+
+type ioduplex struct {
+	io.WriteCloser
+	io.ReadCloser
+}
+
+func (d *ioduplex) Close() error {
+	if err := d.WriteCloser.Close(); err != nil {
+		return err
+	}
+	if err := d.ReadCloser.Close(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func ListenIO(out io.WriteCloser, in io.ReadCloser) (*IOListener, error) {
+	return &IOListener{
+		&ioduplex{out, in},
+	}, nil
+}
+
+func ListenStdio() (*IOListener, error) {
+	return ListenIO(os.Stdout, os.Stdin)
+}

--- a/golang/transport/listen_net.go
+++ b/golang/transport/listen_net.go
@@ -1,0 +1,72 @@
+package transport
+
+import (
+	"io"
+	"net"
+
+	mux "github.com/progrium/qmux/golang"
+	"github.com/progrium/qmux/golang/session"
+)
+
+type NetListener struct {
+	net.Listener
+	accepted chan mux.Session
+	closer   chan bool
+	errs     chan error
+}
+
+func (l *NetListener) Accept() (mux.Session, error) {
+	select {
+	case <-l.closer:
+		return nil, io.EOF
+	case err := <-l.errs:
+		return nil, err
+	case sess := <-l.accepted:
+		return sess, nil
+	}
+}
+
+// func (l *NetListener) Addr() net.Addr {
+// 	return l.Addr()
+// }
+
+func (l *NetListener) Close() error {
+	if l.closer != nil {
+		l.closer <- true
+	}
+	return l.Listener.Close()
+}
+
+func listenNet(proto, addr string) (*NetListener, error) {
+	l, err := net.Listen(proto, addr)
+	if err != nil {
+		return nil, err
+	}
+	closer := make(chan bool, 1)
+	errs := make(chan error, 1)
+	accepted := make(chan mux.Session)
+	go func(l net.Listener) {
+		for {
+			conn, err := l.Accept()
+			if err != nil {
+				errs <- err
+				return
+			}
+			accepted <- session.New(conn)
+		}
+	}(l)
+	return &NetListener{
+		Listener: l,
+		errs:     errs,
+		accepted: accepted,
+		closer:   closer,
+	}, nil
+}
+
+func ListenTCP(addr string) (*NetListener, error) {
+	return listenNet("tcp", addr)
+}
+
+func ListenUnix(addr string) (*NetListener, error) {
+	return listenNet("unix", addr)
+}

--- a/golang/transport/listen_ws.go
+++ b/golang/transport/listen_ws.go
@@ -1,0 +1,41 @@
+package transport
+
+import (
+	"net"
+	"net/http"
+
+	mux "github.com/progrium/qmux/golang"
+	"github.com/progrium/qmux/golang/session"
+	"golang.org/x/net/websocket"
+)
+
+func HandleWS(l *NetListener, ws *websocket.Conn) {
+	ws.PayloadType = websocket.BinaryFrame
+	sess := session.New(ws)
+	defer sess.Close()
+	l.accepted <- sess
+	l.errs <- mux.Wait(sess)
+}
+
+func ListenWS(addr string) (*NetListener, error) {
+	l, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+	nl := &NetListener{
+		Listener: l,
+		accepted: make(chan mux.Session),
+		errs:     make(chan error, 2),
+		closer:   make(chan bool, 1),
+	}
+	s := &http.Server{
+		Addr: addr,
+		Handler: websocket.Handler(func(ws *websocket.Conn) {
+			HandleWS(nl, ws)
+		}),
+	}
+	go func() {
+		nl.errs <- s.Serve(l)
+	}()
+	return nl, nil
+}

--- a/golang/transport/transport_test.go
+++ b/golang/transport/transport_test.go
@@ -1,0 +1,7 @@
+package transport
+
+import "testing"
+
+func TestTransports(t *testing.T) {
+	t.Fatal("TODO")
+}


### PR DESCRIPTION
some changes i made to this from my earlier versions include breaking the websocket handler out so you can use it separately if you want with your own server. also reorganized and changed the minimal Listener API, which isn't so much part of mux but transports here. Also added some io/stdio stuff because I do that a lot. 