### PR TITLE
golang/session: additional tests

### DIFF
--- a/golang/session/session_test.go
+++ b/golang/session/session_test.go
@@ -3,6 +3,7 @@ package session
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io/ioutil"
 	"net"
 	"testing"
@@ -102,5 +103,24 @@ func TestSessionOpenTimeout(t *testing.T) {
 	}
 	if ch != nil {
 		ch.Close()
+	}
+}
+
+func TestSessionWait(t *testing.T) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	fatal(err, t)
+	defer l.Close()
+
+	conn, err := net.Dial("tcp", l.Addr().String())
+	fatal(err, t)
+	defer conn.Close()
+
+	sess := New(conn)
+	fatal(sess.Close(), t)
+	// wait should return immediately since the connection was closed
+	err = sess.Wait()
+	var netErr net.Error
+	if !errors.As(err, &netErr) {
+		t.Fatalf("expected a network error, but got: %v", err)
 	}
 }

--- a/golang/session/session_test.go
+++ b/golang/session/session_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func fatal(err error, t *testing.T) {
+	t.Helper()
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Start adding a couple additional tests for `session` package:
- context timeout on `Open`
- `Session.Wait`

Also marks `fatal` as a test helper so that errors show the caller's line number
instead of the line inside `fatal`.
