### PR TITLE
javascript: make codec test match API

### DIFF
--- a/javascript/codec/codec_test.ts
+++ b/javascript/codec/codec_test.ts
@@ -3,12 +3,12 @@ import {
 } from "https://deno.land/std/testing/asserts.ts";
 
 import * as codec from "./index.ts";
+import * as msg from "./message.ts";
 
 Deno.test("hello world #1", () => {
     let packet = new Uint8Array(5);
     packet.set([105, 0, 0, 0, 0]);
-    let obj = codec.Decode(packet);
-    let buf = codec.Encode(obj);
+    let obj = codec.Unmarshal(packet) as msg.AnyMessage;
+    let buf = codec.Marshal(obj);
     console.log("Hello", obj, buf);
-
 });


### PR DESCRIPTION
Looks like there were some API changes that weren't integrated into the codec
test.

This looks like it was meant to test what's now `Unmarshal` and `Marshal`.
Since `Unmarshal` returns a `Message` which only has `ID`, that doesn't match
`AnyMessage` which corresponds to more specific types. The cast here doesn't seem
ideal, but should I change the return type or parameter to be compatible?
