### PR TITLE
VSCode settings to use Deno extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "denoland.vscode-deno",
+    "golang.go"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "deno.enable": true,
+  "deno.lint": true,
+  "deno.unstable": true
+}


### PR DESCRIPTION
Since the `javascript` implementation is being tested with Deno this
enables using Deno for intellisense. The VSCode built-in TypeScript
support doesn't recognize the imports ending in `.ts`, so most of the
language features don't work because the imports are not resolved.

This also adds a VSCode list of recommended extensions to help people
with installing Deno and Go support.
